### PR TITLE
Fix(Aviso de links desactualizados/no funcionales)

### DIFF
--- a/docs/proyect-fuego.md
+++ b/docs/proyect-fuego.md
@@ -84,8 +84,8 @@ Si este proyecto te resulta útil o interesante, ¡no olvides dejarle una estrel
 ## 🔗 Links Prácticos
 
 - [Repositorio principal](https://github.com/roxsross/roxs-devops-project90)
-- [Material semanal del programa](https://90diasdedevops.com/)
-- [Comunidad en Discord](https://discord.gg/roxsross)
+- [Material semanal del programa](https://90diasdedevops.com/) // Tira error "DNS_PROBE_FINISHED_NXDOMAIN", debería cambiarse para dirigir al plan de estudio tal vez?
+- [Comunidad en Discord](https://discord.gg/roxsross) // Dice invitación no válida, debería cambiarse
 - [Guía rápida de Docker Compose](https://docs.docker.com/compose/gettingstarted/)
 - [Documentación de Ansible](https://docs.ansible.com/)
 - [Terraform Provider Local](https://registry.terraform.io/providers/hashicorp/local/latest/docs)
@@ -101,7 +101,7 @@ Si este proyecto te resulta útil o interesante, ¡no olvides dejarle una estrel
 - [Play with Docker](https://labs.play-with-docker.com/)
 
 ### ☸️ Kubernetes
-- [Aprendé Kubernetes](https://kubernetes.io/learn/)
+- [Aprendé Kubernetes](https://kubernetes.io/docs/tutorials/kubernetes-basics/)
 
 
 ### ☁️ Terraform


### PR DESCRIPTION
Revisando a detalle la página antes de iniciar con la ruta del día 1 me encontré con varios links que no funcionaban:
* [Aprendé Kubernetes](https://kubernetes.io/learn/) tiraba 404, actualicé con un link de tutoriales de uso dentro de la misma página de Kubernetes.

![image](https://github.com/user-attachments/assets/f623931a-9eb1-46fb-bbb2-f3433ed97d0b)

![image](https://github.com/user-attachments/assets/5aa198c8-e8e9-4fce-8d18-8be7430351d4)

* Los links del enlace de Discord y Material Semanal tampoco andan pero no sabía que enlaces proponer para modificar, así que dejo como comentarios en código los errores y propuestas de cambio.

![image](https://github.com/user-attachments/assets/f59bf290-184f-4db4-ae88-7cdcae4b896d)

![image](https://github.com/user-attachments/assets/447a4521-b80f-4580-96b1-faaeec0cd57f)
